### PR TITLE
filter input files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # actimetric 0.1.1
 
 * Data reading: fix minor bug when reading short files #25
+* Data reading: filter input files so that package only loads gt3x, bin, or cwa files #29
 * Reports: fix minor bug that produced an error if sleep is not calculated but nonwear is #26
 * Bouts: Implemented functionality that allows users to define gaps in bout as a percentage of boutduration or as an absolute number of minutes, and it also allows for the definition of the max gap length #28
 

--- a/R/runActimetric.R
+++ b/R/runActimetric.R
@@ -120,6 +120,7 @@ runActimetric = function(input_directory = NULL, output_directory = NULL, studyn
   # Check directories and list files
   if (dir.exists(input_directory)) files = dir(input_directory, recursive = TRUE, full.names = TRUE)
   if (!dir.exists(input_directory)) files = input_directory
+  files = grep("gt3x$|cwa$|bin$", files, value = TRUE)
   output_directory = file.path(output_directory, paste0("output_", studyname))
   suppressWarnings({
     dir.create(file.path(output_directory, "time_series"), recursive = TRUE)


### PR DESCRIPTION
Closes #29 => Now the package select the input files to load based on the file extension (gt3x, cwa, and bin supported for now)