### PR TITLE
Issue58 actigraph idle sleep

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ LazyData: true
 Suggests: 
     testthat (>= 3.0.0), randomForest, gsignal, rattle
 Config/testthat/edition: 3
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Depends: 
     R (>= 2.10)
 Imports: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Time series: stores classes as factor in time series to ease interpretation #51
 * Documentation: minor revision of documentation for functions check_classifier and getBout #41
+* Reading data: minor revision of ReadAndCalibrate when reading ActiGraph devices with the Idle Sleep Mode activated #58
 
 # actimetric 0.1.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # actimetric 0.1.4
 
-* Time series: stores classes as factor in time series to ease interpretation #51
+* Time series: 
+    - stores classes as factor in time series to ease interpretation #51
+    - fixed minor bug related to assignation of date to sleep periods #60
 * Documentation: minor revision of documentation for functions check_classifier and getBout #41
 * Reading data: minor revision of ReadAndCalibrate when reading ActiGraph devices with the Idle Sleep Mode activated #58
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
     - fixed minor bug related to assignation of date to sleep periods #60
 * Documentation: minor revision of documentation for functions check_classifier and getBout #41
 * Reading data: minor revision of ReadAndCalibrate when reading ActiGraph devices with the Idle Sleep Mode activated #58
+* Feature extraction: numeric features are no longer rounded to 3 decimal places #61
 
 # actimetric 0.1.3
 

--- a/R/ReadAndCalibrate.R
+++ b/R/ReadAndCalibrate.R
@@ -131,7 +131,7 @@ ReadAndCalibrate = function(file, sf, blocksize, blocknumber, inspectfileobject,
         if (ncol(S) == (ncol(data) - 1)) {
           # this block has time gaps while the previous block did not
           S = cbind(S, 1)
-          colnames(S)[4] = "remaining_epochs"
+          colnames(S)[ncol(S)] = "remaining_epochs"
         }
       } else if ("remaining_epochs" %in% colnames(S)) {
         if ((ncol(S) - 1) == ncol(data)) {

--- a/R/aggregate_per_date.R
+++ b/R/aggregate_per_date.R
@@ -104,9 +104,15 @@ aggregate_per_date = function(tsDir, epoch, classifier, classes,
       return(list(starts = starts, ends = ends))
     }
     if ("nighttime.awake" %in% classes) {
+      noons = which(ts$time == "12:00:00")
       start_end_nighttime = find_start_end(ts, column = "activity",
                                            class = c("nighttime.awake", "nighttime.sleep"))
-      start_end_nighttime_dates = ts$date[start_end_nighttime$ends] # dates based on wakeup
+      start_end_nighttime_dates = NULL
+      for (ni in 1:length(start_end_nighttime$ends)) {
+        next_noon = which(noons > start_end_nighttime$ends[ni])[1]
+        start_end_nighttime_dates[ni] = ts$date[noons[next_noon]]
+      }
+      # start_end_nighttime_dates = ts$date[start_end_nighttime$ends] # dates based on wakeup
       rows2fill = which(availableDates %in% start_end_nighttime_dates)
       ds[rows2fill, ci] = as.character(ts$timestamp[start_end_nighttime$starts])
       ds[rows2fill, ci + 1] = as.character(ts$timestamp[start_end_nighttime$ends])

--- a/R/classify.R
+++ b/R/classify.R
@@ -73,8 +73,6 @@ classify = function(data = NULL, parameters = NULL, sf = NULL,
     ts = as.data.frame(cbind(subject, timestamp, ts))
   }
   # round numeric columns
-  numeric_columns = sapply(ts, mode) == 'numeric'
-  ts[numeric_columns] =  round(ts[numeric_columns], 3)
   ts  = do.call(data.frame,lapply(ts, function(x) replace(x, is.infinite(x), NA)))
   ts[is.na(ts)] = 0
   # -------------------------------------------------------------------------

--- a/R/classifySleep.R
+++ b/R/classifySleep.R
@@ -129,6 +129,9 @@ classifySleep = function(anglez, starttime, classifier, infoClassifier, ts, do.s
       ts$activity[which(ts$sleep_periods == 1)] = sleep_id
     }
   }
+  # recode nighttime as nighttime.awake and sleep as nighttime.sleep
+  classes = gsub("nighttime", "nighttime.awake", classes)
+  classes = gsub("sleep", "nighttime.sleep", classes)
   activity = factor(x = ts$activity, levels = 1:length(classes), labels = classes)
   return(activity)
 }

--- a/R/runActimetric.R
+++ b/R/runActimetric.R
@@ -287,6 +287,8 @@ runActimetric = function(input_directory = NULL, output_directory = NULL, studyn
                 nw = rep(0, nrow(data) / (epoch*sf))
               }
             }
+          } else {
+            nw = rep(0, nrow(data) / (epoch*sf))
           }
           nonwear = c(nonwear, nw)
           # enmo per epoch

--- a/R/runActimetric.R
+++ b/R/runActimetric.R
@@ -217,8 +217,15 @@ runActimetric = function(input_directory = NULL, output_directory = NULL, studyn
       hvars = GGIR::g.extractheadervars(I)
       sf = I$sf
       # Extract parameters for reading file in chunks as in GGIR R package
-      readParams = GGIR::get_nw_clip_block_params(monc = I$monc, dformat = I$dformc,
-                                                  sf = sf, params_rawdata = GGIR::load_params()$params_rawdata)
+      # the if statement makes this flexible to adapt to different GGIR versions
+      if ("chunksize" %in% names(as.list(args(GGIR::get_nw_clip_block_params)))) {
+        readParams = GGIR::get_nw_clip_block_params(chunksize = 1, dynrange = 8,
+                                                    monc = I$monc, dformat = I$dformc,
+                                                    sf = sf, rmc.dynamic_range = NULL)
+      } else {
+        readParams = GGIR::get_nw_clip_block_params(monc = I$monc, dformat = I$dformc,
+                                                    sf = sf, params_rawdata = GGIR::load_params()$params_rawdata)
+      }
       blocksize = readParams$blocksize
       isLastBlock = FALSE
       blocknumber = 1; iteration = 1

--- a/R/runActimetric.R
+++ b/R/runActimetric.R
@@ -217,9 +217,8 @@ runActimetric = function(input_directory = NULL, output_directory = NULL, studyn
       hvars = GGIR::g.extractheadervars(I)
       sf = I$sf
       # Extract parameters for reading file in chunks as in GGIR R package
-      readParams = GGIR::get_nw_clip_block_params(chunksize = 1, dynrange = 8,
-                                                  monc = I$monc, dformat = I$dformc,
-                                                  sf = sf, rmc.dynamic_range = NULL)
+      readParams = GGIR::get_nw_clip_block_params(monc = I$monc, dformat = I$dformc,
+                                                  sf = sf, params_rawdata = GGIR::load_params()$params_rawdata)
       blocksize = readParams$blocksize
       isLastBlock = FALSE
       blocknumber = 1; iteration = 1


### PR DESCRIPTION
Fixes #58 => there was a bug when reading ActiGraph data with the idle sleep mode activated, now this is resolved.

Fixes #60 => now actimetric uses the date of the following noon to the wake-up time as indicator of the night for the day-level summaries.

Fixes #61 => numeric columns in features matrix are no longer rounded to 3 decimal places.