### PR TITLE
Fix detection of calendar date for last night in the case recording ends before noon

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Reading data: minor revision of ReadAndCalibrate when reading ActiGraph devices with the Idle Sleep Mode activated #58
 * Feature extraction: numeric features are no longer rounded to 3 decimal places #61
 * Calibration: trycatch function applied to calibration routine for cases in which coefficients cannot be retrieved #63
+* Aggregation per date: fixed minor bug that broke data aggregation in the last sleep period when recording ends before noon #65
 
 # actimetric 0.1.3
 

--- a/R/ReadAndCalibrate.R
+++ b/R/ReadAndCalibrate.R
@@ -85,16 +85,15 @@ ReadAndCalibrate = function(file, sf, blocksize, blocknumber, inspectfileobject,
     }
     # -------------------------------------------------------------------------
     # MODULE 3 - EXTRACT CALIBRATION COEFFICIENTS -----------------------------
-    calCoefs = vm.error.st = vm.error.end = NULL
+    calCoefs = list(offset = c(0,0,0), scale = c(1, 1, 1))
+    vm.error.st = vm.error.end = NA
     if (do.calibration == TRUE & iteration == 1) {
       accCols = which(colnames(data) %in% c("x","y","z"))
-      cal = try(calibrateRaw(data[, accCols], sf = sf, verbose = verbose),silent = T)
-
+      cal = try(calibrateRaw(data[, accCols], sf = sf, verbose = verbose),
+                silent = T)
       if (is.list(cal)) {
         calCoefs = cal$calCoefs; vm.error.st = cal$vm.error.st;
         vm.error.end = cal$vm.error.end
-      } else{
-        calCoefs = list(offset = c(0,0,0), scale = c(1, 1, 1))
       }
     }
     # -------------------------------------------------------------------------

--- a/R/aggregate_per_date.R
+++ b/R/aggregate_per_date.R
@@ -110,7 +110,13 @@ aggregate_per_date = function(tsDir, epoch, classifier, classes,
       start_end_nighttime_dates = NULL
       for (ni in 1:length(start_end_nighttime$ends)) {
         next_noon = which(noons > start_end_nighttime$ends[ni])[1]
-        start_end_nighttime_dates[ni] = ts$date[noons[next_noon]]
+        if (is.na(next_noon)) {
+          # if there is not a next_noon, meaning that recording finished before 12pm
+          # following the last wake up
+          start_end_nighttime_dates[ni] = as.character(as.Date(ts$date[noons[length(noons)]]) + 1)
+        } else {
+          start_end_nighttime_dates[ni] = ts$date[noons[next_noon]]
+        }
       }
       # start_end_nighttime_dates = ts$date[start_end_nighttime$ends] # dates based on wakeup
       rows2fill = which(availableDates %in% start_end_nighttime_dates)

--- a/R/aggregate_per_date.R
+++ b/R/aggregate_per_date.R
@@ -113,7 +113,8 @@ aggregate_per_date = function(tsDir, epoch, classifier, classes,
         if (is.na(next_noon)) {
           # if there is not a next_noon, meaning that recording finished before 12pm
           # following the last wake up
-          start_end_nighttime_dates[ni] = as.character(as.Date(ts$date[noons[length(noons)]]) + 1)
+          prev_noon = max(which(noons < start_end_nighttime$ends[ni]))
+          start_end_nighttime_dates[ni] = as.character(as.Date(ts$date[noons[prev_noon]]) + 1)
         } else {
           start_end_nighttime_dates[ni] = ts$date[noons[next_noon]]
         }


### PR DESCRIPTION
Fixes #65 => The date corresponding to the noon following the detected wake-up time is used to assign a calendar date to each sleep period detected. In the case that the recording ends before 12pm, then assigning the calendar date to the last sleep period detected was problematic and triggered an error. This is now fixed by using the next calendar date

This also includes a minor simplification of the code in the calibration function, this does not affect functionality.